### PR TITLE
add returns on factories deploy methods

### DIFF
--- a/ERC20ForSPL/contracts/ERC20ForSPLFactory.sol
+++ b/ERC20ForSPL/contracts/ERC20ForSPLFactory.sol
@@ -107,7 +107,7 @@ contract ERC20ForSPLFactory is OwnableUpgradeable, UUPSUpgradeable {
 
     /// @notice Deploys a new ERC20ForSPL's BeaconProxy instance
     /// @param tokenMint The Solana-like address of the Token Mint on Solana
-    function deploy(bytes32 tokenMint) external {
+    function deploy(bytes32 tokenMint) external returns(address) {
         if (tokensData[tokenMint].token != address(0)) revert AlreadyExistingERC20ForSPL();
 
         BeaconProxy token = new BeaconProxy(
@@ -122,5 +122,6 @@ contract ERC20ForSPLFactory is OwnableUpgradeable, UUPSUpgradeable {
         tokens.push(address(token));
 
         emit TokenDeploy(tokenMint, address(token));
+        return address(token);
     }
 }

--- a/ERC20ForSPL/contracts/ERC20ForSPLMintableFactory.sol
+++ b/ERC20ForSPL/contracts/ERC20ForSPLMintableFactory.sol
@@ -88,7 +88,7 @@ contract ERC20ForSPLMintableFactory is OwnableUpgradeable, UUPSUpgradeable {
         string memory _symbol,
         string memory _uri,
         uint8 _decimals
-    ) external {
+    ) external returns(bytes32, address) {
         BeaconProxy token = new BeaconProxy(
             address(this),
             abi.encodeWithSelector(
@@ -106,5 +106,6 @@ contract ERC20ForSPLMintableFactory is OwnableUpgradeable, UUPSUpgradeable {
         tokens.push(address(token));
 
         emit TokenDeploy(tokenMint, address(token));
+        return (tokenMint, address(token));
     }
 }


### PR DESCRIPTION
@s-medvedev @0xlucian hey guys, please review these small changes. The change is to return the address ( and the tokenmint when needed ) of the new deployed erc20forspl & erc20forsplmintable tokens. I thought event is enough, but when deploying to factory from another contract you're not able to get the address of the just deploy erc20forspl, now with this return it's possible.