### PR TITLE
Add code to get the SPL address from the event logs

### DIFF
--- a/ERC20ForSPL/scripts/deployERC20ForSPLMintableThruFactory.js
+++ b/ERC20ForSPL/scripts/deployERC20ForSPLMintableThruFactory.js
@@ -4,31 +4,33 @@
 // You can also run a script with `npx hardhat run <script>`. If you do that, Hardhat
 // will compile your contracts, add the Hardhat Runtime Environment's members to the
 // global scope, and execute the script.
-const { ethers, upgrades } = require('hardhat');
-const { expect } = require('chai');
+const { ethers } = require("hardhat");
 
 async function main() {
-    [owner] = ethers.getSigners();
+  const ERC20ForSPLFactoryAddress = "";
+  const ERC20ForSPLFactoryInstance = await ethers.getContractAt(
+    "ERC20ForSPLFactory",
+    ERC20ForSPLFactoryAddress
+  );
 
-    const ERC20ForSPLFactoryAddress = '';
-    const ERC20ForSPLFactoryInstance = await ethers.getContractAt('ERC20ForSPLFactory', ERC20ForSPLFactoryAddress);
-
-    let tx = await ERC20ForSPLFactoryInstance.deploy(
-        'Test Token',
-        'TST',
-        'http://integration-test-link.neoninfra.xyz/erc20forspl-info.json',
-        9,
-        owner.address
-    );
-    await tx.wait(3);
-
-    let mintableToken = await ERC20ForSPLFactoryInstance.tokens();
-    console.log(mintableToken[mintableToken.length - 1], 'tokensData(TOKEN_MINT)');
+  let tx = await ERC20ForSPLFactoryInstance.deploy(
+    "Test Token",
+    "TST",
+    "http://integration-test-link.neoninfra.xyz/erc20forspl-info.json",
+    9
+  );
+  const receipt = await tx.wait(3);
+  console.log("Token Mint:", receipt.logs[3].args[0]);
+  console.log(
+    "Token SPL Address:",
+    bs58.encode(Buffer.from(receipt.logs[3].args[0].slice(2), "hex"))
+  );
+  console.log("Token ERC20 Interface Address:", receipt.logs[3].args[1]);
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
+  console.error(error);
+  process.exitCode = 1;
 });

--- a/ERC20ForSPL/scripts/deployERC20ForSPLMintableThruFactory.js
+++ b/ERC20ForSPL/scripts/deployERC20ForSPLMintableThruFactory.js
@@ -6,11 +6,13 @@
 // global scope, and execute the script.
 const { ethers } = require("hardhat");
 
+const FACTORY_ADDRESS = ""; //Add Devnet or Mainnet ERC20ForSPLMintable Factory address
+
 async function main() {
   const ERC20ForSPLFactoryAddress = "";
   const ERC20ForSPLFactoryInstance = await ethers.getContractAt(
     "ERC20ForSPLFactory",
-    ERC20ForSPLFactoryAddress
+    FACTORY_ADDRESS
   );
 
   let tx = await ERC20ForSPLFactoryInstance.deploy(

--- a/ERC20ForSPL/scripts/deployERC20ForSPLThruFactory.js
+++ b/ERC20ForSPL/scripts/deployERC20ForSPLThruFactory.js
@@ -4,24 +4,30 @@
 // You can also run a script with `npx hardhat run <script>`. If you do that, Hardhat
 // will compile your contracts, add the Hardhat Runtime Environment's members to the
 // global scope, and execute the script.
-const { ethers, upgrades } = require('hardhat');
-const { expect } = require('chai');
+const { ethers } = require("hardhat");
+
+const TOKEN_MINT =
+  "0xa4a420d75f056d9cebb8eda13af07965261cb872b129f99b1ac94525ae8fded3"; // Custom SPLToken on Solana Devnet ( C5h24dhh9PjaVtHmf6CaqXbhi9SgrfwUSQt2MskWRLYr )
+const FACTORY_ADDRESS = ""; //Add Devnet or Mainnet ERC20ForSPL Factory address
 
 async function main() {
-    const TOKEN_MINT = '0xa4a420d75f056d9cebb8eda13af07965261cb872b129f99b1ac94525ae8fded3'; // Custom SPLToken on Solana Devnet ( C5h24dhh9PjaVtHmf6CaqXbhi9SgrfwUSQt2MskWRLYr )
+  const ERC20ForSPLFactoryInstance = await ethers.getContractAt(
+    "ERC20ForSPLFactory",
+    FACTORY_ADDRESS
+  );
 
-    const ERC20ForSPLFactoryAddress = '';
-    const ERC20ForSPLFactoryInstance = await ethers.getContractAt('ERC20ForSPLFactory', ERC20ForSPLFactoryAddress);
+  let tx = await ERC20ForSPLFactoryInstance.deploy(TOKEN_MINT);
+  await tx.wait(3);
 
-    let tx = await ERC20ForSPLFactoryInstance.deploy(TOKEN_MINT);
-    await tx.wait(3);
-
-    console.log(await ERC20ForSPLFactoryInstance.tokensData(TOKEN_MINT), 'tokensData(TOKEN_MINT)');
+  console.log(
+    await ERC20ForSPLFactoryInstance.tokensData(TOKEN_MINT),
+    "tokensData(TOKEN_MINT)"
+  );
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
+  console.error(error);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
This PR adds the code to display the token mint, SPL token and the ERC20 interface addresses on the terminal for **ERC20ForSPLMintable** through the example deploy script `deployERC20ForSPLMintableThruFactory.js`.